### PR TITLE
Update toyANOVA.R to use new `toy.anova` data

### DIFF
--- a/ch_inference_for_means/figures/toyANOVA/toyANOVA.R
+++ b/ch_inference_for_means/figures/toyANOVA/toyANOVA.R
@@ -1,13 +1,13 @@
 library(xtable)
 library(openintro)
 
-by(toy_anova$outcome, toy_anova$group, mean)
-
+by(toy.anova$x1, toy.anova$groups, mean)
+by(toy.anova$x2, toy.anova$groups, mean)
 
 myPDF("toyANOVA.pdf",
       mar = c(1.7, 3.1, 0.5, 0.5),
       mgp = c(2, 0.5, 0))
-plot(toy_anova$outcome,
+plot(toy_anova$x1,
      xlim = c(0.5, 6.5),
      type = "n",
      axes = FALSE,
@@ -18,14 +18,13 @@ rect(-100, -100,
      col = COL[7,3])
 abline(h = seq(-10, 10, 2), col = "#FFFFFF", lwd = 3)
 abline(h = seq(-10, 10, 1), col = "#FFFFFF", lwd = 0.8)
-these <- toy_anova$group %in% c("I", "II", "III")
-dotPlot(toy_anova$outcome[these], toy_anova$group[these],
+dotPlot(toy_anova$x1, toy_anova$groups,
         vertical = TRUE,
         at = 1:3,
         add = TRUE,
         col = COL[1, 3],
         cex = 0.9, pch = 19)
-dotPlot(toy_anova$outcome[!these], toy_anova$group[!these],
+dotPlot(toy_anova$x2, toy_anova$groups,
         vertical = TRUE,
         at = 1:3 + 3,
         add = TRUE,
@@ -37,10 +36,10 @@ abline(v = 3.5, col = "#AAAAAA", lwd = 3)
 abline(v = 3.5, col = "#333333", lwd = 0.8)
 axis(2)
 par(mgp = c(2, 0.45, 0.1))
-axis(1, at = 1:3, gps)
+axis(1, at = 1:3, c("I", "II", "III")
 axis(1, at = 4:6, c("IV", "V", "VI"))
 box()
 dev.off()
 
-xtable(anova(lm(outcome ~ group, toy_anova[these, ])))
-xtable(anova(lm(outcome ~ group, toy_anova[!these, ])))
+xtable(anova(lm(x1 ~ group, toy_anova)))
+xtable(anova(lm(x2 ~ group, toy_anova)))


### PR DESCRIPTION
updated this code to reflect the changed format from the `toy_anova` to `toy.anova` data set in the openitnro package version 1.7.1 so the pdf image could be reproduced. I also added the axis labels on the bottom for groups I-III.
After getting it to work locally, I used the 'suggest edit' on github itself to do this fork/PR. Hopefully I caught all necessary changes.