### PR TITLE
Make document compile with caption3

### DIFF
--- a/ch_inference_for_means/TeX/ch_inference_for_means.tex
+++ b/ch_inference_for_means/TeX/ch_inference_for_means.tex
@@ -648,7 +648,7 @@ of dolphin muscle.
 Elevated mercury concentrations are an important problem
 for both dolphins
 and other animals, like humans, who occasionally eat them.
-\setlength{\captionwidth}{86mm}
+\captionsetup{width=86mm}
 
 \begin{figure}[h]
 \centering
@@ -662,7 +662,7 @@ and other animals, like humans, who occasionally eat them.
 \end{minipage}
 \stdvspace{}
 \end{figure}
-\setlength{\captionwidth}{\mycaptionwidth}
+\captionsetup{width=\mycaptionwidth}
 
 We will identify a confidence interval for the average mercury content in dolphin muscle using a sample of 19 Risso's dolphins from the Taiji area in Japan. The data are summarized in Figure~\ref{summaryStatsOfHgInMuscleOfRissosDolphins}. The minimum and maximum observed values can be used to evaluate whether or not there are clear outliers.
 

--- a/ch_inference_for_props/TeX/ch_inference_for_props.tex
+++ b/ch_inference_for_props/TeX/ch_inference_for_props.tex
@@ -1168,7 +1168,7 @@ Set up appropriate hypotheses for the test.\footnotemark
   standard-quality blades.
   $p_{highQ} - p_{standard} \neq 0.03$.}
 
-\setlength{\captionwidth}{85mm}
+\captionsetup{width=85mm}
 
 \begin{figure}[h]
 \centering
@@ -1183,7 +1183,7 @@ Set up appropriate hypotheses for the test.\footnotemark
 \label{quadcopter_david_j}
 \end{figure}
 
-\setlength{\captionwidth}{\mycaptionwidth}
+\captionsetup{width=\mycaptionwidth}
 
 \D{\newpage}
 

--- a/ch_intro_to_data/TeX/ch_intro_to_data.tex
+++ b/ch_intro_to_data/TeX/ch_intro_to_data.tex
@@ -884,7 +884,7 @@ are actually representative of the population.
 Data collected in this haphazard fashion are called
 \term{anecdotal evidence}.
 
-\setlength{\captionwidth}{\textwidth-75mm}
+\captionsetup{width=\textwidth-75mm}
 \begin{figure}[h]
   \centering
   \hspace{8mm}\Figuress
@@ -899,7 +899,7 @@ Data collected in this haphazard fashion are called
     \label{mnWinter}}
   \end{minipage}
 \end{figure}
-\setlength{\captionwidth}{\mycaptionwidth}
+\captionsetup{width=\mycaptionwidth}
 
 \begin{onebox}{Anecdotal evidence}
 Be careful of data collected in a haphazard fashion.

--- a/ch_regr_simple_linear/TeX/ch_regr_simple_linear.tex
+++ b/ch_regr_simple_linear/TeX/ch_regr_simple_linear.tex
@@ -160,7 +160,7 @@ We consider two of these measurements:
 the total length of each possum, from head to tail,
 and the length of each possum's head.
 
-\setlength{\captionwidth}{0.83\mycaptionwidth}
+\captionsetup{width=0.83\mycaptionwidth}
 \begin{figure}[h]
   \centering
   \Figure[A common brushtail possum of Australia is shown. It has a brown fur coat with some gray sprinkled in along with a face and ears that somewhat resemble a house cat. The possum also has a big bushy tail.]{0.5}{brushtail_possum}
@@ -173,7 +173,7 @@ and the length of each possum's head.
           {CC~BY~2.0~license}.}}
   \label{brushtail_possum}
 \end{figure}
-\setlength{\captionwidth}{\mycaptionwidth}
+\captionsetup{width=\mycaptionwidth}
 
 %Scatterplots were introduced in Chapter~\ref{introductionToData}
 %as a graphical technique to present two numerical variables

--- a/ch_summarizing_data/TeX/ch_summarizing_data.tex
+++ b/ch_summarizing_data/TeX/ch_summarizing_data.tex
@@ -1009,7 +1009,7 @@ Figure~\ref{robustOrNotTable}.
 \end{figure}
 
 % See `loan_int_rate_robust_ex` figure code for calculations.
-\setlength{\captionwidth}{135mm}
+\captionsetup{width=135mm}
 \begin{figure}[ht]
 \centering
 \begin{tabular}{l c cc c cc}
@@ -1034,7 +1034,7 @@ move 26.3\% $\to$ 35\%
   variable been different.}
 \label{robustOrNotTable}
 \end{figure}
-\setlength{\captionwidth}{\mycaptionwidth}
+\captionsetup{width=\mycaptionwidth}
 
 \begin{exercisewrap}
 \begin{nexercise} \label{interestRateWhichIsMoreRobust}

--- a/extraTeX/style/style.tex
+++ b/extraTeX/style/style.tex
@@ -235,7 +235,7 @@
 % 8.3 Caption Width
 \newlength{\mycaptionwidth}
 \setlength{\mycaptionwidth}{0.825\textwidth}
-\setlength{\captionwidth}{\mycaptionwidth}
+\captionsetup{width=\mycaptionwidth}
 \newcommand{\Figure}[3][]{\includegraphics[width=#2\textwidth]{\chapterfolder/figures/#3/#3}}
 \newcommand{\Figures}[4][]{\includegraphics[width=#2\textwidth]{\chapterfolder/figures/#3/#4}}
 \newcommand{\Figuress}[4][]{\includegraphics[width=#2]{\chapterfolder/figures/#3/#4}}

--- a/extraTeX/style/style_simple.tex
+++ b/extraTeX/style/style_simple.tex
@@ -235,7 +235,7 @@
 % 8.3 Caption Width
 \newlength{\mycaptionwidth}
 \setlength{\mycaptionwidth}{0.825\textwidth}
-\setlength{\captionwidth}{\mycaptionwidth}
+\captionsetup{width=\mycaptionwidth}
 \newcommand{\Figure}[3][]{\pdftooltip{\includegraphics[width=#2\textwidth]{\chapterfolder/figures/#3/#3}}{#1}}
 \newcommand{\Figures}[4][]{\pdftooltip{\includegraphics[width=#2\textwidth]{\chapterfolder/figures/#3/#4}}{#1}}
 \newcommand{\Figuress}[4][]{\pdftooltip{\includegraphics[width=#2]{\chapterfolder/figures/#3/#4}}{#1}}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5b9cf8a4-caa1-4c2f-b9d1-8b2ab23ebe6b)

Previously the document doesn't compile for me, with the change it does. Looks like captionwidth is only defined in caption2, in caption3 (or just caption) the syntax is different.